### PR TITLE
Add size to images only in img elements

### DIFF
--- a/source/plugins/system/scriptmerge/scriptmerge.php
+++ b/source/plugins/system/scriptmerge/scriptmerge.php
@@ -435,12 +435,12 @@ class PlgSystemScriptMerge extends JPlugin
 	{
 		$files = array();
 
-		if (preg_match_all('/([a-zA-Z0-9\-\_\/\.]+)\.(png|jpg|jpeg|gif)(\"|\')/i', $body, $matches))
+		if (preg_match_all('/<img(.*?)src=("|\'|)(.*?)("|\'| )(.*?)>/s', $body, $matches))
 		{
 			preg_match('/https?:(.*)/', JURI::base(), $uri_base);
 			preg_match('/\/([a-zA-Z0-9\-\_\.]+)$/', JPATH_SITE, $root_dir);
 
-			foreach ($matches[0] as $imagePath)
+			foreach ($matches[3] as $imagePath)
 			{
 				$imagePath = str_replace($uri_base[1], '', $imagePath);
                 $relativeImagePath = $imagePath;


### PR DESCRIPTION
Regarding the recent image dimensions option that that causes issues with various plugins i believe it should only target to image elements in order to prevent such issues.
I would like to hear your opinion too.

As i see it now i have not set any image extension and perhaps the library we use wont be able to get dimensions for other extensions but it would output either an error or a empty width and height.
