### PR TITLE
local JS Match

### DIFF
--- a/source/plugins/system/scriptmerge/scriptmerge.php
+++ b/source/plugins/system/scriptmerge/scriptmerge.php
@@ -394,7 +394,7 @@ class PlgSystemScriptMerge extends JPlugin
 				}
 
 				// Only try to match local JS
-				if (preg_match('/\.js(\?\w+=\w+)?$/', $match) && !preg_match('/^http:\/\//', $match))
+				if (preg_match('/\.js*?/', $match) && !preg_match('/^http:\/\//', $match))
 				{
 					// Only include files that can be read
 					$match = preg_replace('/\?(.*)/', '', $match);


### PR DESCRIPTION
A fix for Javascript files that are indeed local but may contain a get
request after .js .

Example can be find in the K2 component
components/com_k2/js/k2.js?v2.6.9&sitepath=/

Without the patch the javascript is no within the whole package but
remains alone. After the patch the script is embeddedin the scriptmerge
script url.
