### PR TITLE
local JS Match

### DIFF
--- a/source/plugins/system/scriptmerge/scriptmerge.php
+++ b/source/plugins/system/scriptmerge/scriptmerge.php
@@ -468,7 +468,9 @@ class PlgSystemScriptMerge extends JPlugin
 					continue;
 				}
 
-				if (!preg_match('/\.js(?:\?(?:\w+=)?(?:\w+|[0-9a-z\.\-]+))?$/', $match))
+				if (!preg_match('/\.js*?/', $match))
+				// not working on urls like k2: components/com_k2/js/k2.js?v2.6.9&sitepath=/
+				//if (!preg_match('/\.js(?:\?(?:\w+=)?(?:\w+|[0-9a-z\.\-]+))?$/', $match))
 				{
 					continue;
 				}


### PR DESCRIPTION
#14 update as the issue still persists.

A fix for Javascript files that are indeed local but may contain a get request after .js .

Example can be find in the K2 component
components/com_k2/js/k2.js?v2.6.9&sitepath=/

Without the patch the javascript is no within the whole package but
remains alone. After the patch the script is embeddedin the scriptmerge
script url.
