### PR TITLE
Additional newline between concatenated files

### DIFF
--- a/source/plugins/system/scriptmerge/scriptmerge.php
+++ b/source/plugins/system/scriptmerge/scriptmerge.php
@@ -115,7 +115,7 @@ class PlgSystemScriptMerge extends JPlugin
 						continue;
 					}
 
-					$buffer .= $this->helper->getCssContent($file);
+					$buffer .= $this->helper->getCssContent($file) . PHP_EOL;
 				}
 				else
 				{
@@ -124,7 +124,7 @@ class PlgSystemScriptMerge extends JPlugin
 						continue;
 					}
 
-					$buffer .= $this->helper->getJsContent($file);
+					$buffer .= $this->helper->getJsContent($file) . PHP_EOL;
 				}
 			}
 		}


### PR DESCRIPTION
In cases when last line of concatenated file is ending by comment (especially when using files with attached sourcemaps) concatenated file makes javascript interpreter fail:

`Uncaught SyntaxError: Unexpected token *`

For example when _file1.js_ has such end:
```js
(function() {
}(jQuery));

//# sourceMappingURL=maps/scripts.js.map
```

And _file2.js_ has such beginning:

```js
/**
 *  Comment
 */
```

It's being concatenated into
```
(function() {
}(jQuery));

//# sourceMappingURL=maps/scripts.js.map/**
 *  Comment (Error triggered on this line)
 */
```

Suggested solution is to add newline between concatenated files.

___
Workaround:  Plugin configuration > Compress options > Use comments: Yes